### PR TITLE
Add Poetry and Python 3.8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,35 @@ FROM alpine:3.10
 
 # Expecting bind mount at
 ENV PROJECT_DIR=/project/
+
 # Expect volume mount at
 ENV GATORGRADER_DIR=/root/.local/share/
+
+# Python
+ENV PYTHONUNBUFFERED=1 \
+    # prevents python creating .pyc files
+    PYTHONDONTWRITEBYTECODE=1 \
+    \
+    # pip
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100 \
+    \
+    # poetry
+    # https://python-poetry.org/docs/configuration/#using-environment-variables
+    POETRY_VERSION=1.0.10 \
+    # make poetry install to this location
+    POETRY_HOME="/opt/poetry" \
+    # make poetry create the virtual environment in the project's root
+    # it gets named `.venv`
+    POETRY_VIRTUALENVS_IN_PROJECT=true \
+    # do not ask any interactive question
+    POETRY_NO_INTERACTION=1 \
+    \
+    # paths
+    # this is where our requirements + virtual environment will live
+    PYSETUP_PATH="/opt/pysetup" \
+    VENV_PATH="/opt/pysetup/.venv"
 
 WORKDIR ${PROJECT_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
 # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
 RUN set -ex && echo "Installing packages with apk..." && apk update \
-    && apk add --no-cache bash git python3 ruby-rdoc openjdk11 gradle npm curl gcc build-base libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev sqlite-dev linux-headers \
+    && apk add --no-cache bash git ruby-rdoc openjdk11 gradle npm curl gcc build-base libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev sqlite-dev linux-headers \
     && rm -rf /var/cache/apk/* \
     && echo "Installing pandoc..." \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
@@ -71,7 +71,8 @@ RUN set -ex && echo "Installing packages with apk..." && apk update \
     && pip install --upgrade pip \
     && pyenv rehash \
     && echo "Testing Python..." && python --version \
-    && curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python \
+    && wget -O /get-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py \
+    && python /get-poetry.py && rm /get-poetry.py \
     && echo "Testing Poetry..." && poetry --version \
     && pip install pipenv \
     && echo "Testing Pipenv..." && pipenv --version \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
 # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
 RUN set -ex && echo "Installing packages with apk..." && apk update \
-    && apk add --no-cache bash python3 git ruby-rdoc openjdk11 gradle npm curl gcc build-base libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev sqlite-dev linux-headers \
+    && apk add --no-cache bash git ruby-rdoc openjdk11 gradle npm curl gcc build-base libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev sqlite-dev linux-headers \
     && rm -rf /var/cache/apk/* \
     && echo "Installing pandoc..." \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex && echo "Installing packages with apk..." && apk update \
     && pyenv global $PYTHON_VERSION \
     && pip install --upgrade pip \
     && pyenv rehash \
-    && pip install pipenv proselint \
+    && pip install pipenv \
     && mkdir -p /root/.gradle/ \
     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
 # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
 RUN set -ex && echo "Installing packages with apk..." && apk update \
-    && apk add --no-cache bash git ruby-rdoc openjdk11 gradle npm curl gcc build-base libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev sqlite-dev linux-headers \
+    && apk add --no-cache bash git python3 ruby-rdoc openjdk11 gradle npm curl gcc build-base libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev sqlite-dev linux-headers \
     && rm -rf /var/cache/apk/* \
     && echo "Installing pandoc..." \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,26 +8,26 @@ ENV GATORGRADER_DIR=/root/.local/share/
 
 # Python
 ENV PYTHONUNBUFFERED=1 \
-    # prevents python creating .pyc files
+    # Prevents python from creating .pyc files
     PYTHONDONTWRITEBYTECODE=1 \
     \
-    # pip
+    # Configure pip
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
     \
-    # poetry
+    # Pin the version of poetry
     # https://python-poetry.org/docs/configuration/#using-environment-variables
     POETRY_VERSION=1.0.10 \
-    # make poetry install to this location
+    # Configure poetry install to this location
     POETRY_HOME="/opt/poetry" \
-    # make poetry create the virtual environment in the project's root
+    # Make poetry create the virtual environment in the project's root
     # it gets named `.venv`
     POETRY_VIRTUALENVS_IN_PROJECT=true \
-    # do not ask any interactive question
+    # Do not ask any interactive question
     POETRY_NO_INTERACTION=1 \
     \
-    # paths
+    # Specify the paths for using requirements and virtual environments;
     # this is where our requirements + virtual environment will live
     PYSETUP_PATH="/opt/pysetup" \
     VENV_PATH="/opt/pysetup/.venv"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ ENV PATH="$PYENV_HOME/shims:$PYENV_HOME/bin:$PATH"
 # Define the project directory as the working directory
 WORKDIR ${PROJECT_DIR}
 
+# Specify shared volume storage in the container
 VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
 # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
@@ -69,13 +70,15 @@ RUN set -ex && echo "Installing packages with apk..." && apk update \
     && pyenv global $PYTHON_VERSION \
     && pip install --upgrade pip \
     && pyenv rehash \
+    && echo "Testing Python..." && python --version \
+    && curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python \
+    && echo "Testing Poetry..." && poetry --version \
     && pip install pipenv \
+    && echo "Testing Pipenv..." && pipenv --version \
     && mkdir -p /root/.gradle/ \
     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \
-    && echo "Testing Gradle..." && gradle --version \
-    && curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python \
-    && echo "Testing Python..." && python --version \
-    && echo "Testing Poetry..." && poetry --version
+    && echo "Testing Gradle..." && gradle --version
 
+# Define the default action
 CMD ["gradle", "grade"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN set -ex && echo "Installing Packages with apt-get..." \
     && echo "Installing Pipenv..." \
     && pip install pipenv \
     && echo "Testing Pipenv..." && pipenv --version \
-    && echo "Setting up Gradle..." \
+    && echo "Configuring Gradle..." \
     && mkdir -p /root/.gradle/ \
     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Define the image
 FROM alpine:3.10
 
 # Expecting bind mount at
@@ -13,6 +14,7 @@ ARG PYTHON_VERSION='3.8.5'
 ARG PYENV_HOME=/root/.pyenv
 
 # Configure environment variables for Python
+# when it installs from Pyenv is used by Poetry
 ENV PYTHONUNBUFFERED=1 \
     # Prevent Python from creating .pyc files
     PYTHONDONTWRITEBYTECODE=1 \
@@ -63,23 +65,25 @@ RUN set -ex && echo "Installing packages with apk..." && apk update \
     && echo "Installing mdl and htmlhint..." \
     && gem install mdl \
     && npm install -g htmlhint \
-    && echo "Installing Python 3.8 with pyenv..." \
+    && echo "Installing python 3.8 with pyenv..." \
     && git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
     && rm -rfv $PYENV_HOME/.git \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
     && pip install --upgrade pip \
     && pyenv rehash \
-    && echo "Testing Python..." && python --version \
+    && echo "Testing python..." && python --version \
+    && echo "Installing poetry..." \
     && wget -O /get-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py \
     && python /get-poetry.py && rm /get-poetry.py \
-    && echo "Testing Poetry..." && poetry --version \
+    && echo "Testing poetry..." && poetry --version \
     && pip install pipenv \
-    && echo "Testing Pipenv..." && pipenv --version \
+    && echo "Testing pipenv..." && pipenv --version \
+    && echo "Configuring gradle..." \
     && mkdir -p /root/.gradle/ \
     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \
-    && echo "Testing Gradle..." && gradle --version
+    && echo "Testing gradle..." && gradle --version
 
 # Define the default action
 CMD ["gradle", "grade"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,27 @@ VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
 # && python3 -m pip install --upgrade pip \
 
+# # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
+# RUN set -ex && echo "Installing packages..." && apk update \
+#     && apk add --no-cache bash python3 git ruby-rdoc openjdk11 gradle npm \
+#     && rm -rf /var/cache/apk/* \
+#     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
+#     && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz \
+#     && rm /pandoc.tar.gz \
+#     && echo "Testing pandoc..." \
+#     && /usr/bin/pandoc --version \
+#     && gem install mdl \
+#     && npm install -g htmlhint \
+#     && python3 -m pip install --upgrade pip \
+#     && pip install pipenv proselint \
+#     && mkdir -p /root/.gradle/ \
+#     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
+#     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \
+#     && echo "Testing Gradle..." && gradle --version
+
 # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
 RUN set -ex && echo "Installing packages..." && apk update \
-    && apk add --no-cache bash python3 git ruby-rdoc openjdk11 gradle npm curl linux-headers \
+    && apk add --no-cache bash python3 git ruby-rdoc openjdk11 gradle npm curl gcc build-base libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev sqlite-dev linux-headers \
     && rm -rf /var/cache/apk/* \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
     && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz \
@@ -59,7 +77,7 @@ RUN set -ex && echo "Installing packages..." && apk update \
     && /usr/bin/pandoc --version \
     && gem install mdl \
     && npm install -g htmlhint \
-    && git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME && \
+    && git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
     && rm -rfv $PYENV_HOME/.git \
     && pyenv install $PYTHON_VERSION \
     && pyenv global $PYTHON_VERSION \
@@ -70,7 +88,7 @@ RUN set -ex && echo "Installing packages..." && apk update \
     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \
     && echo "Testing Gradle..." && gradle --version \
-    && curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python3 \
+    && curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python \
     && echo "Testing Python..." && python --version \
     && echo "Testing Poetry..." && poetry --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,44 +38,31 @@ ENV PYTHONUNBUFFERED=1 \
     PYSETUP_PATH="/opt/pysetup" \
     VENV_PATH="/opt/pysetup/.venv"
 
-# Prepend Poetry's home and the .venv directory to PATH
+# Pre-pend Poetry's home and the .venv directory to PATH
 ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH:"
 
+# Pre-pend Pyenv's home and the shim directory to PATH
+ENV PATH="$PYENV_HOME/shims:$PYENV_HOME/bin:$PATH"
+
+# Define the project directory as the working directory
 WORKDIR ${PROJECT_DIR}
 
 VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
-# && python3 -m pip install --upgrade pip \
-
-# # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
-# RUN set -ex && echo "Installing packages..." && apk update \
-#     && apk add --no-cache bash python3 git ruby-rdoc openjdk11 gradle npm \
-#     && rm -rf /var/cache/apk/* \
-#     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
-#     && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz \
-#     && rm /pandoc.tar.gz \
-#     && echo "Testing pandoc..." \
-#     && /usr/bin/pandoc --version \
-#     && gem install mdl \
-#     && npm install -g htmlhint \
-#     && python3 -m pip install --upgrade pip \
-#     && pip install pipenv proselint \
-#     && mkdir -p /root/.gradle/ \
-#     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
-#     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \
-#     && echo "Testing Gradle..." && gradle --version
-
 # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
-RUN set -ex && echo "Installing packages..." && apk update \
+RUN set -ex && echo "Installing packages with apk..." && apk update \
     && apk add --no-cache bash python3 git ruby-rdoc openjdk11 gradle npm curl gcc build-base libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev sqlite-dev linux-headers \
     && rm -rf /var/cache/apk/* \
+    && echo "Installing pandoc..." \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
     && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz \
     && rm /pandoc.tar.gz \
     && echo "Testing pandoc..." \
     && /usr/bin/pandoc --version \
+    && echo "Installing mdl and htmlhint..." \
     && gem install mdl \
     && npm install -g htmlhint \
+    && echo "Installing Python 3.8 with pyenv..." \
     && git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
     && rm -rfv $PYENV_HOME/.git \
     && pyenv install $PYTHON_VERSION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ ENV PYTHONUNBUFFERED=1 \
     PYSETUP_PATH="/opt/pysetup" \
     VENV_PATH="/opt/pysetup/.venv"
 
+# Prepend poetry and venv to path
+ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
+
 WORKDIR ${PROJECT_DIR}
 
 VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,20 +45,23 @@ WORKDIR ${PROJECT_DIR}
 VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
 # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
-RUN set -ex && echo "Installing packages with apt-get..." && apk update \
-    && apk add --no-cache bash git ruby-rdoc openjdk11 gradle npm \
-    && rm -rf /var/cache/apk/* \
-    && echo "Installing pandoc..." \
+RUN set -ex && echo "Installing Packages with apt-get..." \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends bash git ruby openjdk-11-jdk gradle npm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "Installing Pandoc..." \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
     && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz && rm /pandoc.tar.gz \
-    && echo "Testing pandoc..." \
+    && echo "Testing Pandoc..." \
     && /usr/bin/pandoc --version \
-    && echo "Installing mdl" \
+    && echo "Installing Markdown Linter called mdl..." \
     && gem install mdl \
-    && echo "Installing htmlhint" \
+    && echo "Installing HTML Linter called htmlhint..." \
     && npm install -g htmlhint \
     && echo "Testing Python..." && python --version \
-    && echo "Upgrading Pip" \
+    && echo "Upgrading Pip..." \
     && pip install --upgrade pip \
     && echo "Testing Pip..." && pip --version \
     && echo "Installing Poetry..." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Define the image to feature:
+# --> Operating System: Debian Buster
+# --> Python Version: 3.8.5
 FROM python:3.8.5-buster
 
 # Expecting bind mount at

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,18 @@ FROM alpine:3.10
 # Expecting bind mount at
 ENV PROJECT_DIR=/project/
 
-# Expect volume mount at
+# Expecting volume mount at
 ENV GATORGRADER_DIR=/root/.local/share/
 
 # Set Python version
 ARG PYTHON_VERSION='3.8.5'
-# Set pyenv home
+
+# Set Pyenv home
 ARG PYENV_HOME=/root/.pyenv
 
-# Python
+# Configure environment variables for Python
 ENV PYTHONUNBUFFERED=1 \
-    # Prevents python from creating .pyc files
+    # Prevent Python from creating .pyc files
     PYTHONDONTWRITEBYTECODE=1 \
     \
     # Configure pip
@@ -21,26 +22,24 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
     \
-    # Pin the version of poetry
-    # https://python-poetry.org/docs/configuration/#using-environment-variables
+    # Pin the version of Poetry
     POETRY_VERSION=1.0.10 \
-    # Configure poetry install to this location
+    # Configure Poetry's installation directory
     POETRY_HOME="/opt/poetry" \
     # Make poetry create the virtual environment in the project's root
-    # it gets named `.venv`
+    # This virtual environment will be called .venv
     POETRY_VIRTUALENVS_IN_PROJECT=true \
-    # Do not ask any interactive question
+    # Do not ask any interactive questions
+    # during the installation of Poetry
     POETRY_NO_INTERACTION=1 \
     \
     # Specify the paths for using requirements and virtual environments;
-    # this is where our requirements + virtual environment will live
+    # this is where the requirements + virtual environment will live
     PYSETUP_PATH="/opt/pysetup" \
     VENV_PATH="/opt/pysetup/.venv"
 
-# Prepend poetry and venv to path
+# Prepend Poetry's home and the .venv directory to PATH
 ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH:"
-
-ENV PATH="$PYENV_HOME/shims:$PYENV_HOME/bin:$PATH"
 
 WORKDIR ${PROJECT_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,7 @@ ENV PROJECT_DIR=/project/
 # Expecting volume mount at
 ENV GATORGRADER_DIR=/root/.local/share/
 
-# Set Python version
-ARG PYTHON_VERSION='3.8.5'
-
-# Configure environment variables for Python
+# Configure environment variables
 ENV PYTHONUNBUFFERED=1 \
     # Prevent Python from creating .pyc files
     PYTHONDONTWRITEBYTECODE=1 \
@@ -36,10 +33,15 @@ ENV PYTHONUNBUFFERED=1 \
     # Specify the paths for using requirements and virtual environments;
     # this is where the requirements + virtual environment will live
     PYSETUP_PATH="/opt/pysetup" \
-    VENV_PATH="/opt/pysetup/.venv"
+    VENV_PATH="/opt/pysetup/.venv" \
+    # Specify the version of Gradle
+    GRADLE_VERSION=5.4.1 \
+    # Specify the home directory of Gradle
+    GRADLE_HOME="/opt/gradle-5.4.1"
 
 # Pre-pend Poetry's home and the .venv directory to PATH
-ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH:"
+# Pre-pend Gradle's bin to PATH
+ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$GRADLE_HOME/bin:$PATH"
 
 # Define the project directory as the working directory
 WORKDIR ${PROJECT_DIR}
@@ -47,18 +49,21 @@ WORKDIR ${PROJECT_DIR}
 # Specify shared volume storage in the container
 VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
-# hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
-RUN set -ex && echo "Installing Packages with apt-get..." \
+# Tell Docker to use a bash login shell for RUN commands
+SHELL ["/bin/bash", "--login", "-c"]
+
+# hadolint ignore=DL3008,DL3013,DL3016,DL3018,DL3028
+RUN set -e && echo "Installing Packages with apt-get..." \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-    && apt-get -y install --no-install-recommends bash git ruby openjdk-11-jdk gradle npm \
+    && apt-get -y install --no-install-recommends ruby openjdk-11-jdk npm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && echo "Installing Pandoc..." \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
     && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz && rm /pandoc.tar.gz \
     && echo "Testing Pandoc..." \
-    && /usr/bin/pandoc --version \
+    && pandoc --version \
     && echo "Installing Markdown Linter called mdl..." \
     && gem install mdl \
     && echo "Installing HTML Linter called htmlhint..." \
@@ -69,12 +74,17 @@ RUN set -ex && echo "Installing Packages with apt-get..." \
     && echo "Testing Pip..." && pip --version \
     && echo "Installing Poetry..." \
     && wget -O /get-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py \
-    && python /get-poetry.py && rm /get-poetry.py \
+    && python /get-poetry.py --version $POETRY_VERSION && rm /get-poetry.py \
+    && source $POETRY_HOME/env \
     && echo "Testing Poetry..." && poetry --version \
     && echo "Installing Pipenv..." \
     && pip install pipenv \
     && echo "Testing Pipenv..." && pipenv --version \
+    && echo "Installing Gradle..." \
+    && wget -O /gradle-bin.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+    && unzip /gradle-bin.zip -d /opt && rm /gradle-bin.zip \
     && echo "Configuring Gradle..." \
+    && export PATH="$GRADLE_HOME/bin:$PATH" \
     && mkdir -p /root/.gradle/ \
     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ ENV PROJECT_DIR=/project/
 # Expect volume mount at
 ENV GATORGRADER_DIR=/root/.local/share/
 
+# Set Python version
+ARG PYTHON_VERSION='3.8.5'
+# Set pyenv home
+ARG PYENV_HOME=/root/.pyenv
+
 # Python
 ENV PYTHONUNBUFFERED=1 \
     # Prevents python from creating .pyc files
@@ -33,15 +38,19 @@ ENV PYTHONUNBUFFERED=1 \
     VENV_PATH="/opt/pysetup/.venv"
 
 # Prepend poetry and venv to path
-ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
+ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH:"
+
+ENV PATH="$PYENV_HOME/shims:$PYENV_HOME/bin:$PATH"
 
 WORKDIR ${PROJECT_DIR}
 
 VOLUME ${PROJECT_DIR} ${GATORGRADER_DIR}
 
+# && python3 -m pip install --upgrade pip \
+
 # hadolint ignore=DL3008,DL3013,DL3015,DL3016,DL3018,DL3028
 RUN set -ex && echo "Installing packages..." && apk update \
-    && apk add --no-cache bash python3 git ruby-rdoc openjdk11 gradle npm \
+    && apk add --no-cache bash python3 git ruby-rdoc openjdk11 gradle npm curl linux-headers \
     && rm -rf /var/cache/apk/* \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
     && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz \
@@ -50,12 +59,19 @@ RUN set -ex && echo "Installing packages..." && apk update \
     && /usr/bin/pandoc --version \
     && gem install mdl \
     && npm install -g htmlhint \
-    && python3 -m pip install --upgrade pip \
+    && git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME && \
+    && rm -rfv $PYENV_HOME/.git \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pip install --upgrade pip \
+    && pyenv rehash \
     && pip install pipenv proselint \
     && mkdir -p /root/.gradle/ \
     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \
-    && echo "Testing Gradle..." && gradle --version
-
+    && echo "Testing Gradle..." && gradle --version \
+    && curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python3 \
+    && echo "Testing Python..." && python --version \
+    && echo "Testing Poetry..." && poetry --version
 
 CMD ["gradle", "grade"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ ENV PYTHONUNBUFFERED=1 \
     \
     # Specify the paths for using requirements and virtual environments;
     # this is where the requirements + virtual environment will live
-    PYSETUP_PATH="/opt/pysetup" \
-    VENV_PATH="/opt/pysetup/.venv" \
+    PYSETUP_PATH="/root/.local/share/pysetup" \
+    VENV_PATH="/root/.local/share/pysetup/.venv" \
     # Specify the version of Gradle
     GRADLE_VERSION=5.4.1 \
     # Specify the home directory of Gradle


### PR DESCRIPTION
This pull request adds support for the following programs to this Docker container:

- Support for Python 3.8.5 through the use of the Debian Buster base image that provides Python 3.8.5
- Support for the Poetry tool for managing Python virtual environments and application dependencies
- The `git` command-line client, which will allow for the use of, for instance, `git status` in the Docker container

The reasons for installing these two programs are as follows:

- Several courses are now using Python 3.8. However, students who are using Windows are having trouble installing this program through the Pyenv-Win tool. This means that these students can now use the Docker container instead of struggling to install Python 3.8.5 on their laptops.

- Instead of using Pipenv for managing virtual environments and packages, I am now starting to use Poetry as it is faster and has more features. Including this program in the Docker container will therefore support future courses as well.

It is important to note that this Docker container no longer uses Alpine, instead opting for Debian Buster. I have tested almost ten different assignments with this Docker container and found that it always worked correctly, focusing on assignments from the following courses: CMPSC 100, CMPSC 101, CMPSC 102, CMPSC 203, and CMPSC 302.

There are several important points to consider about using this Docker container instead of the previous one:

- Since it uses Python 3.8.5 students who previously used the old Docker container will find that their virtual environments in the `.dockagator` directory no longer work correctly. The only way around this issue is to have the delete the two (or three) directories inside of `.dockagator`. In all of my testing, I can confirm that deleting these directories always allowed `gradle grade` to pass when it should.

- Since this Docker container is based on Debian Buster instead of Alpine, this means that the diagnostic display from `gradle grade` and the prompt in the terminal window are slightly different. For instance, here is what the prompt now looks like:

```
root@759d4cbac1bc:/project#
```

this means that some students and student technical leaders may be confused about whether or not  they are actually in the Docker container.

- This Docker container is larger than the one before by about 500 MB. During my testing, I did not notice a significant difference is execution time with this Docker container, once it was downloaded. However, it is possible that using this Docker container will lead to longer initial download times, especially for those students who are using slower laptops.