### PR TITLE
Update base image to python:3.8.5-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,7 @@ RUN set -ex && echo "Installing packages with apk..." && apk update \
     && rm -rf /var/cache/apk/* \
     && echo "Installing pandoc..." \
     && wget -O /pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz \
-    && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz \
-    && rm /pandoc.tar.gz \
+    && tar -C /usr --strip-components 1 -xzvf /pandoc.tar.gz && rm /pandoc.tar.gz \
     && echo "Testing pandoc..." \
     && /usr/bin/pandoc --version \
     && echo "Installing mdl" \
@@ -67,7 +66,7 @@ RUN set -ex && echo "Installing packages with apk..." && apk update \
     && pip install pipenv \
     && echo "Testing Pipenv..." && pipenv --version \
     && mkdir -p /root/.gradle/ \
-    && echo "org.gradle.daemon=false" >> /root/.gradle/gradle.properties \
+    && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \
     && echo "Testing Gradle..." && gradle --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,14 +57,18 @@ RUN set -ex && echo "Installing packages with apk..." && apk update \
     && gem install mdl \
     && echo "Installing htmlhint" \
     && npm install -g htmlhint \
+    && echo "Testing Python..." && python --version \
     && echo "Upgrading Pip" \
     && pip install --upgrade pip \
-    && echo "Testing Python..." && python --version \
+    && echo "Testing Pip..." && pip --version \
+    && echo "Installing Poetry..." \
     && wget -O /get-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py \
     && python /get-poetry.py && rm /get-poetry.py \
     && echo "Testing Poetry..." && poetry --version \
+    && echo "Installing Pipenv..." \
     && pip install pipenv \
     && echo "Testing Pipenv..." && pipenv --version \
+    && echo "Setting up Gradle..." \
     && mkdir -p /root/.gradle/ \
     && echo "org.gradle.daemon=true" >> /root/.gradle/gradle.properties \
     && echo "systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false" >> /root/.gradle/gradle.properties \


### PR DESCRIPTION
This removes Pyenv and changes the base image to `python:3.8.5-alpine` which then provides Python 3.8.5 for GatorGrader, Pipenv, and Poetry.